### PR TITLE
Implemented Iterable interface for Dictionary 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@ replay_pid*
 ##############################
 ## Eclipse
 ##############################
-#.project
+.project
 .settings/
 bin/
 tmp/

--- a/src/java/com/augursolutions/wordler/Word.java
+++ b/src/java/com/augursolutions/wordler/Word.java
@@ -3,6 +3,7 @@ package com.augursolutions.wordler;
 import java.util.ArrayList;
 import java.util.List;
 
+
 public class Word {
 
 	public enum Part_Of_Speech {
@@ -73,6 +74,7 @@ public class Word {
 	public void setPartsOfSpeech(List<Part_Of_Speech> partsOfSpeech) {
 		this.partsOfSpeech = partsOfSpeech;
 	}
+	
 	//CONVERSION TO CHAR[]
 	public char[] toChars() {
 		if(this.letters == null || this.letters.isEmpty())
@@ -81,9 +83,18 @@ public class Word {
 		this.letters.getChars(0, this.letters.length(), chars, 0);
 		return chars;
 	}
+	
 	public int length() {
 		if(this.letters == null)
 			return 0;
 		return this.letters.length();
+	}
+	
+	public String toString() {
+		return this.getLetters() == null ? "" : this.getLetters();
+	}
+	
+	public int compare(Word w1, Word w2) {
+		return w1.getLetters().compareTo(w2.getLetters());
 	}
 }


### PR DESCRIPTION
# Overview
Dictionary now implements Iterable - added a custom Iterator class (WordIterator) that navigates the tree in alphabetical order
# Other Changes
- Added test cases for new iterator 
- ignore project files

#Change Log

## Dictionary.java
 - DictionaryNode uses a NavigableMap for children - allows iterator to get "first" and "next" child
 - WordIterator class to handle iteration. 
 - Some test cases to verify that iterator hits all words in alphabetical order and that next() throws a NoSuchElementException correctly

## Word.java
 - Added toString() method to aid in debugging (Word objects now display the letters of the word instead of the address in debugger)
 - Added a compare method to support TreeSet<Word> objects and general Word sorting 

## .gitignore
ignore the eclipse project file
